### PR TITLE
Fix BERTopic handling for single input

### DIFF
--- a/multi_keywords.py
+++ b/multi_keywords.py
@@ -144,11 +144,20 @@ def main():
 
             # BERTopic extraction (if available)
             if BERTopic is not None:
-                topic_model = BERTopic(verbose=False)
-                topics, _ = topic_model.fit_transform([combined_text])
-                topic_keywords = topic_model.get_topic(0) or []
-                topic_keywords = topic_keywords[:5]
-                print("Top 5 BERTopic keywords:", [kw for kw, _ in topic_keywords])
+                if len(texts) > 1:
+                    topic_model = BERTopic(verbose=False)
+                    topics, _ = topic_model.fit_transform(texts)
+                    topic_keywords = topic_model.get_topic(0) or []
+                    topic_keywords = topic_keywords[:5]
+                    print(
+                        "Top 5 BERTopic keywords:",
+                        [kw for kw, _ in topic_keywords],
+                    )
+                else:
+                    topic_keywords = []
+                    print(
+                        "Only one text provided; skipping BERTopic extraction.",
+                    )
             else:
                 topic_keywords = []
                 print("BERTopic not installed; skipping BERTopic extraction.")


### PR DESCRIPTION
## Summary
- improve BERTopic block in `multi_keywords.py`
- only run BERTopic when multiple texts are provided

## Testing
- `python -m py_compile multi_keywords.py`

------
https://chatgpt.com/codex/tasks/task_e_684cfe022e6c832682edacc77e874953