### PR TITLE
Increase SERP wait time

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Optional features require additional libraries as noted below.
 ## Usage
 
 - **`demo_keywords.py`** prompts for a single text block, extracts keywords with RAKE and KeyBERT, and writes the results to text files.
-- **`multi_keywords.py`** allows multiple texts and can optionally use YAKE and BERTopic for extra keywords, plus Selenium scraping of Google SERPs. Results are written to `keyword_alternatives_multi.txt` and `keyword_serp_multi.txt`.
+- **`multi_keywords.py`** allows multiple texts and can optionally use YAKE and BERTopic for extra keywords, plus Selenium scraping of Google SERPs. The scraper waits 60 seconds after opening each results page so you can solve any CAPTCHA. Results are written to `keyword_alternatives_multi.txt` and `keyword_serp_multi.txt`.
 
 Both scripts print instructions interactively when run.
 

--- a/multi_keywords.py
+++ b/multi_keywords.py
@@ -24,7 +24,7 @@ except Exception:
 
 warnings.filterwarnings("ignore", category=FutureWarning)
 
-def scrape_google_serp(url, num_results=5):
+def scrape_google_serp(url, num_results=5, wait=60):
 
     options = Options()
     driver = None
@@ -33,9 +33,10 @@ def scrape_google_serp(url, num_results=5):
         driver = webdriver.Firefox(
             service=Service(GeckoDriverManager().install()), options=options
         )
-        driver.set_page_load_timeout(30)
+        driver.set_page_load_timeout(max(wait, 30))
         driver.get(url)
-        time.sleep(5)  # Wait for page to load, increase if needed
+        print(f"Waiting {wait} seconds for the page to load. Solve any CAPTCHA if present...")
+        time.sleep(wait)
 
         # For debugging: Save current HTML
         with open("last_serp_debug.html", "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- increase SERP wait time to 60 seconds to allow manual CAPTCHA solving
- document new delay in README

## Testing
- `python -m py_compile multi_keywords.py demo_keywords.py download_nltk_data.py`

------
https://chatgpt.com/codex/tasks/task_e_684d0816bd1483268bb5f0bc17d7d729