### PR TITLE
Broaden SERP keywords and run multi pipeline 3x

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Optional features require additional libraries as noted below.
 ## Usage
 
 - **`demo_keywords.py`** prompts for a single text block, extracts keywords with RAKE and KeyBERT, and writes the results to text files.
-- **`multi_keywords.py`** allows multiple texts and can optionally use YAKE and BERTopic for extra keywords, plus Playwright scraping of Google SERPs. Each results page opens in a browser and the script pauses until you press Enter so you can solve any CAPTCHA. Results are written to `keyword_alternatives_multi.txt` and `keyword_serp_multi.txt`.
+- **`multi_keywords.py`** allows multiple texts and can optionally use YAKE and BERTopic for extra keywords, plus Playwright scraping of Google SERPs. The pipeline now runs three times automatically to provide a wider variety of keywords. Each results page opens in a browser and the script pauses until you press Enter so you can solve any CAPTCHA. Results are written to `keyword_alternatives_multi.txt` and `keyword_serp_multi.txt`.
 
 Both scripts print instructions interactively when run.
 

--- a/multi_keywords.py
+++ b/multi_keywords.py
@@ -78,10 +78,14 @@ def main():
         texts.append(txt)
     combined_text = " ".join(texts)
 
-    try:
-        num_runs = int(input("How many times to run the pipeline? (default 1): ").strip() or 1)
-    except ValueError:
-        num_runs = 1
+    # Always run the pipeline three times to generate a broader set of
+    # keywords.  The previous implementation prompted the user for this
+    # value, but the repeated prompt often led to the same keywords being
+    # selected across executions.  Running the extraction loop a fixed
+    # number of times gives BERTopic and the other extractors more data to
+    # work with without requiring additional input.
+    num_runs = 3
+    print("Running the pipeline 3 times...")
 
     with open("keyword_alternatives_multi.txt", "w") as alt_f, \
          open("keyword_serp_multi.txt", "w", encoding="utf-8") as serp_f, \
@@ -190,7 +194,11 @@ def main():
 
             # Human-in-the-loop scraping: prompt for each keyword
             serp_f.write(f"=== Run {run} ===\n")
-            for kw in list(phrases):
+            # Use the combined list of unique keywords from all extraction
+            # methods so Google searches cover RAKE, YAKE, KeyBERT and
+            # BERTopic results.  This helps diversify the search terms and
+            # reduces repetition across runs.
+            for _, kw, _ in unique_kw:
                 print(f"\n[!] Search for this keyword in Google: '{kw}'")
                 print("    1. Open your browser, search this keyword on Google.")
                 print("    2. Copy the URL of the results page.")


### PR DESCRIPTION
## Summary
- run `multi_keywords.py` three times automatically
- use the deduplicated keywords from every extractor for Google searches
- document the new behavior in the README

## Testing
- `python -m py_compile multi_keywords.py`


------
https://chatgpt.com/codex/tasks/task_e_684d1dfcac848326af35cab463605542