### PR TITLE
Run pipeline once

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Optional features require additional libraries as noted below.
 ## Usage
 
 - **`demo_keywords.py`** prompts for a single text block, extracts keywords with RAKE and KeyBERT, and writes the results to text files.
-- **`multi_keywords.py`** allows multiple texts and can optionally use YAKE and BERTopic for extra keywords, plus Playwright scraping of Google SERPs. The pipeline now runs three times automatically to provide a wider variety of keywords. Each results page opens in a browser and the script pauses until you press Enter so you can solve any CAPTCHA. Results are written to `keyword_alternatives_multi.txt` and `keyword_serp_multi.txt`.
+- **`multi_keywords.py`** allows multiple texts and can optionally use YAKE and BERTopic for extra keywords, plus Playwright scraping of Google SERPs. Because keywords are gathered from RAKE, KeyBERT and YAKE in a single pass, the pipeline only needs to run once. Each results page opens in a browser and the script pauses until you press Enter so you can solve any CAPTCHA. Results are written to `keyword_alternatives_multi.txt` and `keyword_serp_multi.txt`.
 
 Both scripts print instructions interactively when run.
 

--- a/multi_keywords.py
+++ b/multi_keywords.py
@@ -78,14 +78,11 @@ def main():
         texts.append(txt)
     combined_text = " ".join(texts)
 
-    # Always run the pipeline three times to generate a broader set of
-    # keywords.  The previous implementation prompted the user for this
-    # value, but the repeated prompt often led to the same keywords being
-    # selected across executions.  Running the extraction loop a fixed
-    # number of times gives BERTopic and the other extractors more data to
-    # work with without requiring additional input.
-    num_runs = 3
-    print("Running the pipeline 3 times...")
+    # With RAKE, KeyBERT and YAKE all enabled in a single pass, running the
+    # pipeline once provides plenty of keywords.  Multiple runs are no longer
+    # necessary, so we fix the loop to a single iteration.
+    num_runs = 1
+    print("Running the pipeline once...")
 
     with open("keyword_alternatives_multi.txt", "w") as alt_f, \
          open("keyword_serp_multi.txt", "w", encoding="utf-8") as serp_f, \


### PR DESCRIPTION
## Summary
- run the multi-keyword pipeline only once
- update docs for single run

## Testing
- `python -m py_compile demo_keywords.py multi_keywords.py download_nltk_data.py`

------
https://chatgpt.com/codex/tasks/task_e_684d5ed6d2048326a2c8067cb146b649